### PR TITLE
refact: check if extractor class exist for v4.3.0

### DIFF
--- a/SoraStream/src/main/kotlin/com/hexated/SoraStreamPlugin.kt
+++ b/SoraStream/src/main/kotlin/com/hexated/SoraStreamPlugin.kt
@@ -7,6 +7,17 @@ import android.content.Context
 
 @CloudstreamPlugin
 class SoraStreamPlugin: Plugin() {
+
+    private fun classExist(className: String) : Boolean {
+        try {
+            Class.forName(className)
+        } catch (e: Exception) {
+            return false
+        }
+
+        return true
+    }
+
     override fun load(context: Context) {
         // All providers should be added in this manner. Please don't edit the providers list directly.
         registerMainAPI(SoraStream())
@@ -19,7 +30,11 @@ class SoraStreamPlugin: Plugin() {
         registerExtractorAPI(TravelR())
         registerExtractorAPI(Playm4u())
         registerExtractorAPI(VCloud())
-        registerExtractorAPI(Pixeldra())
+
+        if (classExist("com.lagradost.cloudstream3.extractors.PixelDrain")) {
+            registerExtractorAPI(Pixeldra())
+        }
+        
         registerExtractorAPI(M4ufree())
         registerExtractorAPI(Streamruby())
         registerExtractorAPI(Streamwish())


### PR DESCRIPTION
![Screenshot_2024-03-26-22-54-58-902_com lagradost cloudstream3_1](https://github.com/hexated/cloudstream-extensions-hexated/assets/164035730/65f68749-5c86-4abd-bec4-d6dc160b7e9d)

Confuse users when shows Error in v.4.3.0