### PR TITLE
hotfix: added check if class exist for v4.3.0

### DIFF
--- a/SoraStream/src/main/kotlin/com/hexated/SoraStreamPlugin.kt
+++ b/SoraStream/src/main/kotlin/com/hexated/SoraStreamPlugin.kt
@@ -7,6 +7,15 @@ import android.content.Context
 
 @CloudstreamPlugin
 class SoraStreamPlugin: Plugin() {
+    private fun classExist(className: String) : Boolean {
+        try {
+            Class.forName(className, false, ClassLoader.getSystemClassLoader())
+        } catch (e: ClassNotFoundException) {
+            return false
+        }
+
+        return true
+    }
     override fun load(context: Context) {
         // All providers should be added in this manner. Please don't edit the providers list directly.
         registerMainAPI(SoraStream())
@@ -19,7 +28,19 @@ class SoraStreamPlugin: Plugin() {
         registerExtractorAPI(TravelR())
         registerExtractorAPI(Playm4u())
         registerExtractorAPI(VCloud())
-        registerExtractorAPI(Pixeldra())
+
+        /*
+            Check if class exists before load
+            v.4.3.0 released 20231209
+            Class added on 20231231
+
+            2cfdab54 (Extractor: added some extractors (#833), 2023-12-31)
+            app/src/main/java/com/lagradost/cloudstream3/extractors/PixelDrainExtractor.kt
+         */
+        if (classExist("com.lagradost.cloudstream3.extractors.PixelDrain")) {
+            registerExtractorAPI(Pixeldra())
+        }
+
         registerExtractorAPI(M4ufree())
         registerExtractorAPI(Streamruby())
         registerExtractorAPI(Streamwish())


### PR DESCRIPTION
This error confuses users?
![Screenshot_2024-03-26-22-54-58-902_com lagradost cloudstream3_1](https://github.com/hexated/cloudstream-extensions-hexated/assets/164035730/a675afc8-5eef-48a4-92fe-9dcd21e1b0e9)
`E PluginManager: Failed to load Cloudstream3/plugins/SoraStream.cs3: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/lagradost/cloudstream3/extractors/PixelDrain;`